### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -2,6 +2,8 @@ wordpress-plugin-http-authentication (4.7-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Repository, Repository-Browse.
   * Use canonical URL in Vcs-Git.
+  * Remove field Section on binary package wordpress-plugin-http-authentication
+    that duplicates source.
 
  -- Debian Janitor <janitor@jelmer.uk>  Fri, 22 Jul 2022 13:00:52 -0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+wordpress-plugin-http-authentication (4.7-2) UNRELEASED; urgency=medium
+
+  * Set upstream metadata fields: Repository, Repository-Browse.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Fri, 22 Jul 2022 13:00:52 -0000
+
 wordpress-plugin-http-authentication (4.7-1) sid; urgency=low
 
   * Unifying license file (according to github user majority).

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,7 @@
 wordpress-plugin-http-authentication (4.7-2) UNRELEASED; urgency=medium
 
   * Set upstream metadata fields: Repository, Repository-Browse.
+  * Use canonical URL in Vcs-Git.
 
  -- Debian Janitor <janitor@jelmer.uk>  Fri, 22 Jul 2022 13:00:52 -0000
 

--- a/debian/control
+++ b/debian/control
@@ -9,7 +9,7 @@ Rules-Requires-Root: no
 Standards-Version: 4.6.1
 Homepage: https://github.com/sunflowerbofh/http-authentication
 Vcs-Browser: https://github.com/sunflowerbofh/http-authentication
-Vcs-Git: https://github.com/sunflowerbofh/http-authentication
+Vcs-Git: https://github.com/sunflowerbofh/http-authentication.git
 
 Package: wordpress-plugin-http-authentication
 Section: web

--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,6 @@ Vcs-Browser: https://github.com/sunflowerbofh/http-authentication
 Vcs-Git: https://github.com/sunflowerbofh/http-authentication.git
 
 Package: wordpress-plugin-http-authentication
-Section: web
 Architecture: all
 Depends:
  wordpress,

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,3 @@
+---
+Repository: https://github.com/sunflowerbofh/http-authentication.git
+Repository-Browse: https://github.com/sunflowerbofh/http-authentication


### PR DESCRIPTION
Fix some issues reported by lintian

* Set upstream metadata fields: Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository))

* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical))

* Remove field Section on binary package wordpress-plugin-http-authentication that duplicates source. ([installable-field-mirrors-source](https://lintian.debian.org/tags/installable-field-mirrors-source))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/lintian-fixes.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/wordpress-plugin-http-authentication/e3813606-e3a2-40f3-8bb7-a4986e9f10ca.



These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/e3813606-e3a2-40f3-8bb7-a4986e9f10ca/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e3813606-e3a2-40f3-8bb7-a4986e9f10ca/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e3813606-e3a2-40f3-8bb7-a4986e9f10ca/diffoscope)).
